### PR TITLE
7-8

### DIFF
--- a/addons.opy
+++ b/addons.opy
@@ -30,7 +30,7 @@ rule "Addon | Add Blade to Checkpoint <---- EDIT ME":
 rule "Addon | Add Dash to Checkpoint <---- EDIT ME":
     @Disabled
     #Change "-1" to certain Checkpoints' number. For example if you want to add Dash to Checkpoint 7 and 1 change one of "-1" to 7 and other "-1" to 1
-    wait(1)
+    wait(1) 
     DashEnabledCheckpoints = [[], -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1]
     
 rule "Addon | Title Data <---- EDIT ME":
@@ -128,6 +128,7 @@ rule "Addon | pre-set control map portal | placement | toggled via workshop":
     else:
         PortalDest = null
         return
+        
 rule "Addon | pre-set control map portal | function | toggled via workshop":
     @Event eachPlayer
     @Condition PortalOn

--- a/changelog.txt
+++ b/changelog.txt
@@ -208,3 +208,9 @@ fixed:
 
 1.7.7 - 12-2-2023
     - added support for new map ANTARCTIC PENINSULA (DVa, Portals)
+
+1.7.8 - 24-2-2023
+    - fixed a bug that caused teleports checkpoints to wait before trigering
+    - fixed wallclimb ban rule incorectly having the editme tag while not requiring editing (this is done in ban per cp rule)
+    - more addon data now cleaned on saving map in editor map, preventing some bugs
+    - ban per cp now defaults to -1. this doesnt functionally change anything other then give you an array by default instead of empty array

--- a/editor.opy
+++ b/editor.opy
@@ -43,6 +43,14 @@ rule "Editor | Clear Excess Data to Save Map":
     LeaderBoardFull = []
     PortalOn = false
 
+    TitleData = null
+    CpHudText = null
+    CpHudCp = null
+    CpIwtText = null
+    CpIwtCp = null
+    CpIwtPos = null
+    CpIwtColor = null
+
     enableInspector()
 
     hudText(eventPlayer,  

--- a/genji.opy
+++ b/genji.opy
@@ -52,7 +52,7 @@ rule "------------------------------------------------------------------------ M
     @Delimiter
     @Disabled
 
-rule "Map Data     <---- INSERT YOUR MAP DATA HERE":
+rule "Map Data <---- INSERT YOUR MAP DATA HERE":
     @Delimiter
 
 
@@ -72,17 +72,17 @@ rule "Ban per CP <---- edit me":
     wait(1)
     # ======================
     # ban  triple >
-    BanTriple = []
+    BanTriple = [-1]
     # ban  multi >
-    BanMulti = []
+    BanMulti = [-1]
     # ban create >
-    BanCreate = []
+    BanCreate = [-1]
     # ban dedhop >
-    BanDead = []
+    BanDead = [-1]
     # ban emote >
-    BanEmote = []
+    BanEmote = [-1]
     # ban  climb >
-    BanClimb = []
+    BanClimb = [-1]
     # ======================
     # dash exploit (via toggles don't edit)
     DashExploitToggle = createWorkshopSetting(bool, "Ban Switch", "Ban Dash Start", false, 2)
@@ -107,7 +107,7 @@ rule "Display World Record":
     HudStoreEdit.append(getLastCreatedText())
 
 
-rule "Friend Title <----  DISPLAY MESSAGE HERE (ON PLAYER)":
+rule "Friend Title <---- DISPLAY MESSAGE HERE (ON PLAYER)":
     @Disabled
     @Delimiter
     @Event eachPlayer
@@ -420,8 +420,7 @@ rule "Match time":
     pauseMatchTime()
     wait(5)
     TimeRemaining = 265
-    #hudSubheader(getAllPlayers(), "  Server Restarts In {0} Min  ".format(TimeRemaining), HudPosition.RIGHT, HO.data_remaingtime, Color.RED, HudReeval.VISIBILITY_AND_STRING, SpecVisibility.ALWAYS)
-    hudSubheader(getAllPlayers(), "Server Restarts In {0} Min - V1.7.7".format(TimeRemaining), HudPosition.RIGHT, HO.data_remaingtime, Color.RED, HudReeval.VISIBILITY_AND_STRING, SpecVisibility.ALWAYS)
+    hudSubheader(getAllPlayers(), "Server Restarts In {0} Min - V1.7.8".format(TimeRemaining), HudPosition.RIGHT, HO.data_remaingtime, Color.RED, HudReeval.VISIBILITY_AND_STRING, SpecVisibility.ALWAYS)
     
     while TimeRemaining > 0:
         wait(60)
@@ -858,6 +857,12 @@ rule "Arrive | Ground reset | traces":
             eventPlayer.LockCollected = []
             eventPlayer.CurrentCheckpoint += 1
             UpdateCache()
+            if len(CheckpointPositions[eventPlayer.CurrentCheckpoint]) > 1:# teleport cps
+                eventPlayer.startForcingPosition( CheckpointPositions[eventPlayer.CurrentCheckpoint].last() ,false)
+                wait(0.1)
+                eventPlayer.flytoggle = null
+                eventPlayer.stopForcingPosition()
+            
             eventPlayer.splitdisplay =  (eventPlayer.practicetimer if eventPlayer.PracticeToggle else eventPlayer.Timer) - eventPlayer.splittime
             wait()
             playEffect(eventPlayer, DynamicEffect.RING_EXPLOSION_SOUND, Color.WHITE, eventPlayer, 100)
@@ -872,7 +877,7 @@ rule "Arrive | Ground reset | traces":
                 goto lbl_abc
             
             eventPlayer.splittime = eventPlayer.Timer
-
+                
             if eventPlayer.CurrentCheckpoint == len(CheckpointPositions) - 1 and (not eventPlayer.EditorOn) and (not eventPlayer.PracticeToggle): # complete lvl
                 stopChasingVariable(eventPlayer.Timer)
                 stopChasingVariable(eventPlayer.practicetimer) 
@@ -894,13 +899,13 @@ rule "Arrive | Ground reset | traces":
             else: # update save
                 DeleteSave()
                 MakeSave()
-
         elif distance(eventPlayer,CheckpointPositions[eventPlayer.CurrentCheckpoint].last()) > 1.4 and not touchground:
             # ground reset ----------------------------------------------------------------------------------------------------
             checkpointFailReset()
 
     lbl_abc:
     wait(0.048)
+
     if RULE_CONDITION:
         goto RULE_START               
    

--- a/mechanics.opy
+++ b/mechanics.opy
@@ -135,7 +135,6 @@ rule "Checking | Double jump, initialized with small jump":
     if (eventPlayer.JumpCount != 0 or eventPlayer.WallclimbUsed) and eventPlayer.isOnGround():
         goto RULE_START
     eventPlayer.BhopUsed = true
-
     #if (eventPlayer.JumpCount != 0 or eventPlayer.WallclimbUsed) and eventPlayer.isOnGround():
 
 rule "HUD | Multiclimb Counter":
@@ -160,7 +159,7 @@ rule "--------------------------------------------------------------------------
     @Delimiter
     @Disabled
 
-rule "Ban | Wallclimb for specific CPs <---- EDIT ME":
+rule "Ban | Wallclimb for specific CPs":
     # Credit: TITANXPASCAL#5554
     @Event eachPlayer
     @Condition eventPlayer.ban_climb
@@ -182,8 +181,6 @@ rule "Ban | Triple Jump":
     smallMessage(eventPlayer, "   Triple Jump ▲ is banned!")
     checkpointFailReset()
 
-
-
 rule "Ban | Multiclimb":
     @Event eachPlayer
     @Condition eventPlayer.ban_multi
@@ -202,62 +199,3 @@ rule "Ban | Emote Savehop":
     smallMessage(eventPlayer, "   Emote Savehop ♥ is banned!")
     checkpointFailReset()
 
-
-
-
-
-
-
-/*
-old multi hud
-rule "HUD | Multiclimbs Used":
-    @Event eachPlayer
-    @Condition not eventPlayer.WallclimbUsed
-    @Condition eventPlayer.hasSpawned() == true
-    
-    destroyHudText(eventPlayer.MultiClimbCountHUD)
-    hudHeader(eventPlayer, "Climb{0}".format("({0})".format(eventPlayer.MultiClimbCount) if eventPlayer.MultiClimbCount > 0 else ""), HudPosition.LEFT, HO.game_climb, Color.GREEN, HudReeval.VISIBILITY_AND_STRING, SpecVisibility.DEFAULT)
-    eventPlayer.MultiClimbCountHUD = getLastCreatedText()
- 
-
-rule "HUD | Wallclimb Used":
-    @Event eachPlayer
-    @Condition eventPlayer.WallclimbUsed
-    @Condition eventPlayer.hasSpawned() == true
-
-    destroyHudText(eventPlayer.MultiClimbCountHUD)
-    hudHeader(eventPlayer, "Climb", HudPosition.LEFT, HO.game_climb, Color.RED, HudReeval.VISIBILITY_AND_STRING, SpecVisibility.DEFAULT)
-    eventPlayer.MultiClimbCountHUD = getLastCreatedText()
-*/
-
-/*
-# bricked because u can fallbhop, and it can triger on usign double
-rule "Ban | Bhop for specific CPs      <---- EDIT ME":
-    # Credit: TITANXPASCAL#5554
-    @Event eachPlayer
-    @Condition eventPlayer.ban_bhop
-    @Condition not eventPlayer.InvincibleToggle
-    @Condition eventPlayer.NotOnLastCp
-    #@Condition 
-    @Condition not eventPlayer.LockState
-    @Condition distance(eventPlayer,CheckpointPositions[eventPlayer.CurrentCheckpoint].last()) > 1.4
-    #@Condition distance(eventPlayer, CheckpointPositions[eventPlayer.CurrentCheckpoint + 1]) <= 2
-    if eventPlayer.BhopUsed == 1: 
-        checkpointFailReset()
-        smallMessage(eventPlayer, "   Bhop is banned!")
-*/
-
-/*
-# removed coz duplicatewith "Checking | Double jump, initialized with small jump"
-rule "Checking | Bhop/Double Jump Initialization":
-    @Event eachPlayer
-    @Hero genji
-    @Condition eventPlayer.isOnGround() == true
-
-    eventPlayer.JumpCount = 0
-    eventPlayer.WallclimbUsed = false
-    wait(0)
-    if (eventPlayer.JumpCount != 0 or eventPlayer.WallclimbUsed) and eventPlayer.isOnGround():
-        goto RULE_START
-    eventPlayer.BhopUsed = true
-*/

--- a/settings.opy
+++ b/settings.opy
@@ -3,7 +3,7 @@
 settings {
     "main": {
         "description": "  ~ The Official Genji Parkour Editor ~\nCode: 54CRY\nAdapted by: nebula#11571/FishoFire#2431",
-        "modeName": "Genji Parkour v1.7.7"
+        "modeName": "Genji Parkour v1.7.8"
     },
     "lobby": {
         "allowPlayersInQueue": true,


### PR DESCRIPTION
1.7.8 - 24-2-2023
    - fixed a bug that caused teleports checkpoints to wait before trigering
    - fixed wallclimb ban rule incorectly having the editme tag while not requiring editing (this is done in ban per cp rule)
    - more addon data now cleaned on saving map in editor map, preventing some bugs
    - ban per cp now defaults to -1. this doesnt functionally change anything other then give you an array by default instead of empty array
